### PR TITLE
Disable running script as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This script installs Zig and the Zig Language Server (ZLS). You can choose to install both or just one of them.
 
+[!Note] You should not run a root. Run the script as the user that will use Zig and ZLS. Sudo will be requested if when/if necessary and you may be prompted for your password at that time.
+
 ## Prerequisites
 
 Before running the script, ensure you have the following dependencies installed:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This script installs Zig and the Zig Language Server (ZLS). You can choose to install both or just one of them.
 
-[!Note] You should not run a root. Run the script as the user that will use Zig and ZLS. Sudo will be requested if when/if necessary and you may be prompted for your password at that time.
+**Note:** You should not run a root. Run the script as the user that will use Zig and ZLS. Sudo will be requested if when/if necessary and you may be prompted for your password at that time.
 
 ## Prerequisites
 

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,13 @@ help() {
   exit 0
 }
 
+check_user() {
+  if [ "$(id -u)" -eq 0 ]; then
+    echo "Please run this script as a non-root user."
+    exit 1
+  fi
+}
+
 check_dependencies() {
   local pkgs=("git" "wget" "jq" "minisign")
   for pkg in "${pkgs[@]}"; do
@@ -47,6 +54,7 @@ check_version() {
 
 download_version() {
   if [[ ! -d /opt/zig ]]; then
+    echo "!! Sudo password may be required for creating zig directory. !!"
     sudo mkdir -p /opt/zig
     sudo chown -R "$(whoami)":"$(whoami)" /opt/zig
   fi
@@ -92,6 +100,7 @@ install_version() {
   echo "Installing Zig version: ${version}"
   tar -xf "/opt/zig/${tarfile}" -C "/opt/zig/"
   rm "/opt/zig/${tarfile}"
+  echo "!! Sudo password may be required for installing zig. !!"
   sudo ln -sf "/opt/zig/zig-linux-x86_64-${version}/zig" /usr/local/bin/zig
 
   if [[ -f /usr/local/bin/zig ]]; then
@@ -119,6 +128,7 @@ fetch_zls() {
     fi
   else
     echo "Fetching ZLS."
+    echo "!! Sudo password may be required for creating zls directory. !!"
     sudo mkdir -p /opt/zls
     sudo chown -R "$(whoami)":"$(whoami)" /opt/zls
     git clone https://github.com/zigtools/zls.git /opt/zls
@@ -139,8 +149,10 @@ install_zls() {
 }
 
 main() {
-  local cwd
+  check_user
   check_dependencies
+
+  local cwd
   cwd=$(pwd)
   if [[ "$#" -eq 0 ]]; then
     zig_install

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,6 @@ check_version() {
 
 download_version() {
   if [[ ! -d /opt/zig ]]; then
-    echo "!! Sudo password may be required for creating zig directory. !!"
     sudo mkdir -p /opt/zig
     sudo chown -R "$(whoami)":"$(whoami)" /opt/zig
   fi
@@ -100,7 +99,6 @@ install_version() {
   echo "Installing Zig version: ${version}"
   tar -xf "/opt/zig/${tarfile}" -C "/opt/zig/"
   rm "/opt/zig/${tarfile}"
-  echo "!! Sudo password may be required for installing zig. !!"
   sudo ln -sf "/opt/zig/zig-linux-x86_64-${version}/zig" /usr/local/bin/zig
 
   if [[ -f /usr/local/bin/zig ]]; then
@@ -128,7 +126,6 @@ fetch_zls() {
     fi
   else
     echo "Fetching ZLS."
-    echo "!! Sudo password may be required for creating zls directory. !!"
     sudo mkdir -p /opt/zls
     sudo chown -R "$(whoami)":"$(whoami)" /opt/zls
     git clone https://github.com/zigtools/zls.git /opt/zls
@@ -149,6 +146,8 @@ install_zls() {
 }
 
 main() {
+  echo "!! Sudo password may be required !!"
+
   check_user
   check_dependencies
 


### PR DESCRIPTION
Sudo is used when necessary throughout the script. The script in intended to run as the user for proper dir and file permissions.